### PR TITLE
Resolve conflicting CC wired modem recipe

### DIFF
--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -439,6 +439,15 @@ function tweaks(event) {
 		M: "computercraft:turtle_normal",
 		S: MC('gold_ingot')
 	})
+	event.shaped("computercraft:wired_modem", [
+		'SSS',
+		'SRS',
+		'SIS'
+	], {
+		R: MC('redstone'),
+		S: MC('stone'),
+		I: MC('iron_ingot')
+	})
 
 	event.shaped("forbidden_arcanus:eternal_stella", [
 		'PEP',


### PR DESCRIPTION
The recipe for the Futura (Screen Metalic) block conflicts with the default wired modem recipe.

This change adds another recipe for the wired modem.