### PR TITLE
Fixes #50

### DIFF
--- a/config/ftbquests/quests/chapters/overview.snbt
+++ b/config/ftbquests/quests/chapters/overview.snbt
@@ -487,6 +487,7 @@
 					id: "6530AB7AA277197D"
 					type: "item"
 					item: "create:mechanical_mixer"
+					consume_items: false
 				}
 			]
 			rewards: [{


### PR DESCRIPTION
Update 'Preparations' quest requirements to no longer consume Mechanical Mixer item.

Also mentioned in #121