### PR TITLE
Added black dye as valid dye for Chromatic Singularity recipe

### DIFF
--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -1887,7 +1887,7 @@ function invarMachine(event) {
 
 	event.recipes.createCrushing([Item.of(AE2("singularity")).withChance(1)], CR('crushing_wheel')).processingTime(250)
 
-	let dyes = [MC('orange_dye'), MC('magenta_dye'), MC('light_blue_dye'), MC('yellow_dye'), MC('lime_dye'), MC('pink_dye'), MC('cyan_dye'), MC('purple_dye'), MC('blue_dye'), MC('brown_dye'), MC('green_dye'), MC('red_dye')]
+	let dyes = [MC('orange_dye'), MC('magenta_dye'), MC('light_blue_dye'), MC('yellow_dye'), MC('lime_dye'), MC('pink_dye'), MC('cyan_dye'), MC('purple_dye'), MC('blue_dye'), MC('brown_dye'), MC('green_dye'), MC('red_dye'), MC('black_dye')]
 	event.recipes.createCompacting('1x ' + KJ("dye_entangled_singularity"), [dyes, Item.of(AE2('quantum_entangled_singularity'), 1)])
 	event.recipes.createConversion([AE2('quantum_entangled_singularity')], AE2("singularity"))
 	event.recipes.createCrushing([


### PR DESCRIPTION
According to the quest book, you should be able to use any dye besides white dye to create the Chromatic Singularity using the press. It looks like black dye is not set as a valid option, though, so this commit fixes that issue.

This has been tested on both v1.1 and v1.3 of the modpack.