### PR TITLE
Farmer's Delight Crops Phytogenic Insolator recipes

### DIFF
--- a/kubejs/server_scripts/recipes.js
+++ b/kubejs/server_scripts/recipes.js
@@ -2113,6 +2113,8 @@ function enderMachine(event) {
 	event.recipes.thermal.insolator(['endergetic:tall_poise_bush'], 'endergetic:poise_bush').water(1000)
 	event.recipes.thermal.insolator(['endergetic:poise_cluster'], 'endergetic:tall_poise_bush').water(1000)
 	event.recipes.thermal.insolator(['tconstruct:ender_slime_ball', '3x endergetic:poise_bush'], 'endergetic:poise_cluster').water(1000)
+        event.recipes.thermal.insolator(['2x farmersdelight:onion'], 'farmersdelight:onion').water(500)
+        event.recipes.thermal.insolator(['2x farmersdelight:rice_panicle'], 'farmersdelight:rice').water(1000)
 
 	// let t = KJ('incomplete_abstruse_mechanism')
 	// event.recipes.createSequencedAssembly([


### PR DESCRIPTION
It didn't seem consistent to me that the cabbage and tomatos from Farmer's Delight could be grown in the Phytogenic Insolator, but not the rice and onions.  This just adds those two recipes for consistency.